### PR TITLE
feat: drop support for Python earlier than 3.6.7, or 3.7.1 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,10 @@ jobs:
             os: "ubuntu-20.04"
           - python-version: "3.10.0"
             os: "ubuntu-20.04"
+          - python-version: "3.11.0"
+            os: "ubuntu-20.04"
+          - python-version: "3.12.0"
+            os: "ubuntu-20.04"
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout"
@@ -31,7 +35,7 @@ jobs:
           python-version: '${{ matrix.python-version }}'
       - name: "Install python dependencies"
         run: |
-          pip install coverage
+          pip install ".[dev]"
       - name: "Run tests"
         run: |
           coverage run -m unittest -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,16 @@ authors = [
 ]
 description = "Uncompress DEFLATE streams in pure Python"
 readme = "README.md"
-requires-python = ">=3.5.0"
+requires-python = ">=3.6.7, !=3.7.0"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
     "Topic :: System :: Archiving :: Compression",
+]
+
+[project.optional-dependencies]
+dev = [
+    "coverage",
 ]
 
 [project.urls]


### PR DESCRIPTION
This is done because these versions are not available using GitHub action's setup-python action, and so these versions just don't get tested. Given these Python versions' ages, suspect it's not worth to test them, and opting to be honest about the versions of Python that are supported.

(This also includes tests for later versions of Python while at it)