### PR TITLE
ci: use token to upload to CodeCov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,4 +39,6 @@ jobs:
       - name: "Run tests"
         run: |
           pytest --cov -v
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
To avoid hitting limits for token-less uploads. And bumping to v4 while at it.