### PR TITLE
perf: avoid lambda on every step of algorithm

### DIFF
--- a/stream_inflate.py
+++ b/stream_inflate.py
@@ -164,8 +164,8 @@ def _stream_inflate(length_extra_bits_diffs, dist_extra_bits_diffs, cache_size, 
     # Bit/byte readers that are DeferredYielder
     def get_deferred_yielder_readers(reader_has_bit, reader_has_byte, reader_get_bit, reader_get_byte, reader_yield_bytes_up_to):
 
-        get_bit = DeferredYielder(can_proceed=reader_has_bit, to_yield=lambda: (), num_from_cache=lambda: (0, 0), return_value=reader_get_bit)
-        get_byte = DeferredYielder(can_proceed=reader_has_byte, to_yield=lambda: (), num_from_cache=lambda: (0, 0), return_value=reader_get_byte)
+        get_bit = DeferredYielder(can_proceed=reader_has_bit, to_yield=lambda: (), num_from_cache=(0, 0), return_value=reader_get_bit)
+        get_byte = DeferredYielder(can_proceed=reader_has_byte, to_yield=lambda: (), num_from_cache=(0, 0), return_value=reader_get_byte)
 
         def get_bits(num_bits):
             out = bytearray(-(-num_bits // 8))
@@ -199,7 +199,7 @@ def _stream_inflate(length_extra_bits_diffs, dist_extra_bits_diffs, cache_size, 
                     num_bytes -= len(chunk)
                     yield chunk
 
-            yield_bytes_up_to = DeferredYielder(can_proceed=reader_has_byte, to_yield=to_yield, num_from_cache=lambda: (0, 0), return_value=lambda: None)
+            yield_bytes_up_to = DeferredYielder(can_proceed=reader_has_byte, to_yield=to_yield, num_from_cache=(0, 0), return_value=lambda: None)
 
             while num_bytes:
                 yield yield_bytes_up_to
@@ -283,7 +283,7 @@ def _stream_inflate(length_extra_bits_diffs, dist_extra_bits_diffs, cache_size, 
                 if not can_proceed():
                     return
                 yield from via_cache(to_yield())
-                yield from via_cache(from_cache(*num_from_cache()))
+                yield from via_cache(from_cache(num_from_cache[0], num_from_cache[1]))
                 can_proceed = None
 
             is_done = True
@@ -385,10 +385,10 @@ def _stream_inflate(length_extra_bits_diffs, dist_extra_bits_diffs, cache_size, 
         return result
 
     def yield_exactly(bytes_to_yield):
-        return DeferredYielder(can_proceed=lambda: True, to_yield=lambda: (bytes_to_yield,), num_from_cache=lambda: (0, 0), return_value=lambda: None)
+        return DeferredYielder(can_proceed=lambda: True, to_yield=lambda: (bytes_to_yield,), num_from_cache=(0, 0), return_value=lambda: None)
 
     def yield_from_cache(dist, length):
-        return DeferredYielder(can_proceed=lambda: True, to_yield=lambda: (), num_from_cache=lambda: (dist, length), return_value=lambda: None)
+        return DeferredYielder(can_proceed=lambda: True, to_yield=lambda: (), num_from_cache=(dist, length), return_value=lambda: None)
 
     def inflate(get_bits, get_bytes, yield_bytes):
         b_final = b'\0'


### PR DESCRIPTION
This shaves a few % off the runtime