### PR TITLE
ci: build Windows, not macOS 11 and tidy version replacement

### DIFF
--- a/.github/workflows/deploy-package-to-pypi.yml
+++ b/.github/workflows/deploy-package-to-pypi.yml
@@ -12,13 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Update version in pyproject.toml from current git tag
-        run: >-
-          sed -i.bak "s/0\\.0\\.0\\.dev0/${GITHUB_REF/refs\/tags\/v/}/g" pyproject.toml && rm pyproject.toml.bak
-
-      - name: Update version in setup.py from current git tag
-        run: >-
-          sed -i.bak "s/0\\.0\\.0\\.dev0/${GITHUB_REF/refs\/tags\/v/}/g" setup.py && rm setup.py.bak
+      - name: Update version in pyproject.toml and setup.py from current git tag
+        run: |
+          sed -i "s/0\\.0\\.0\\.dev0/${GITHUB_REF_NAME}/g" pyproject.toml
+          sed -i "s/0\\.0\\.0\\.dev0/${GITHUB_REF_NAME}/g" setup.py
 
       - name: Build packages
         run: >-
@@ -47,7 +44,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - "macos-11"
           - "macos-12"
           - "macos-13"
           - "macos-14"  # ARM
@@ -72,13 +68,10 @@ jobs:
         with:
           python-version: '${{ matrix.python-version }}'
 
-      - name: Update version in pyproject.toml from current git tag
-        run: >-
-          sed -i.bak "s/0\\.0\\.0\\.dev0/${GITHUB_REF/refs\/tags\/v/}/g" pyproject.toml && rm pyproject.toml.bak
-
-      - name: Update version in setup.py from current git tag
-        run: >-
-          sed -i.bak "s/0\\.0\\.0\\.dev0/${GITHUB_REF/refs\/tags\/v/}/g" setup.py && rm setup.py.bak
+      - name: Update version in pyproject.toml and setup.py from current git tag
+        run: |
+          sed -i "" "s/0\\.0\\.0\\.dev0/${GITHUB_REF_NAME}/g" pyproject.toml
+          sed -i "" "s/0\\.0\\.0\\.dev0/${GITHUB_REF_NAME}/g" setup.py
 
       - name: Build package
         run: |
@@ -90,46 +83,42 @@ jobs:
           name: ${{ matrix.os }}-${{ matrix.python-version }}
           path: ./dist
 
-  # The sed command wasn't quite working
-  # build-windows:
-  #   name: Build Windows wheels
-  #   strategy:
-  #     matrix:
-  #       os:
-  #         - "windows-2019"
-  #       python-version:
-  #         - "3.6.7"
-  #         - "3.7.1"
-  #         - "3.8.0"
-  #         - "3.9.0"
-  #         - "3.10.0"
-  #         - "3.11.0"
-  #         - "3.12.0"
-  #   runs-on: '${{ matrix.os }}'
+  build-windows:
+    name: Build Windows wheels
+    strategy:
+      matrix:
+        os:
+          - "windows-2019"
+        python-version:
+          - "3.6.7"
+          - "3.7.1"
+          - "3.8.0"
+          - "3.9.0"
+          - "3.10.0"
+          - "3.11.0"
+          - "3.12.0"
+    runs-on: '${{ matrix.os }}'
 
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions/setup-python@v4
-  #       with:
-  #         python-version: '${{ matrix.python-version }}'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '${{ matrix.python-version }}'
 
-  #     - name: Update version in pyproject.toml from current git tag
-  #       run: >-
-  #         sed -i "s/0\\.0\\.0\\.dev0/${GITHUB_REF/refs\/tags\/v/}/g" pyproject.toml
+      - name: Update version in pyproject.toml and setup.py from current git tag
+        run: |
+          (Get-Content pyproject.toml).Replace('0.0.0.dev0', $Env:GITHUB_REF_NAME) | Set-Content pyproject.toml
+          (Get-Content setup.py).Replace('0.0.0.dev0', $Env:GITHUB_REF_NAME) | Set-Content setup.py
 
-  #     - name: Update version in setup.py from current git tag
-  #       run: >-
-  #         sed -i "s/0\\.0\\.0\\.dev0/${GITHUB_REF/refs\/tags\/v/}/g" setup.py
+      - name: Build package
+        run: |
+          pip install build
+          python -m build --wheel
 
-  #     - name: Build package
-  #       run: |
-  #         pip install build
-  #         python -m build --wheel
-
-  #     - uses: actions/upload-artifact@v4
-  #       with:
-  #         name: ${{ matrix.os }}-${{ matrix.python-version }}
-  #         path: ./dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.os }}-${{ matrix.python-version }}
+          path: ./dist
 
   deploy:
     needs: [build-linux, build-macos]


### PR DESCRIPTION
GitHub actions no longer has macOS 11 runners