### PR TITLE
ci: fix code coverage off-by-two errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,14 +33,10 @@ jobs:
       - uses: "actions/setup-python@v4"
         with:
           python-version: '${{ matrix.python-version }}'
-      - name: "Enable code coverage"
-        run: |
-          echo '# cython: linetrace=True' | cat - stream_inflate.py > temp && mv temp stream_inflate.py
-          echo '# distutils: define_macros=CYTHON_TRACE=1' | cat - stream_inflate.py > temp && mv temp stream_inflate.py
       - name: "Install python dependencies"
         run: |
-          pip install '.[dev]'
-          python setup.py build_ext --inplace
+          STREAM_INFLATE_CODE_COVERAGE=1 pip install '.[dev]'
+          STREAM_INFLATE_CODE_COVERAGE=1 python setup.py build_ext --inplace
       - name: "Run tests"
         run: |
           pytest --cov -v

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,21 @@
+import os
 from setuptools import setup, Extension
 from Cython.Build import cythonize
 
+macros, compiler_directives = \
+    ([('CYTHON_TRACE', '1')], {'linetrace': True}) if os.environ.get('STREAM_INFLATE_CODE_COVERAGE') == '1' else \
+    ([], {})
+
+print('Building...')
+print('macros:', macros)
+print('compiler_directives:', compiler_directives)
+
 setup(
-    ext_modules=cythonize("stream_inflate.py"),
+    ext_modules=cythonize([Extension(
+        "stream_inflate",
+        ["stream_inflate.py"],
+        define_macros=macros,
+    )], compiler_directives=compiler_directives),
     # Python 3.6 seems to need all of the below, even though they are in pyproject.toml
     name="stream-inflate",
     version="0.0.0.dev0",


### PR DESCRIPTION
The slightly hack of putting in comments into the code made the code coverage reports off-by-two in terms of where the lines get covered or not