### PR TITLE
ci: fix publish workflow file

### DIFF
--- a/.github/workflows/deploy-package-to-pypi.yml
+++ b/.github/workflows/deploy-package-to-pypi.yml
@@ -233,7 +233,13 @@ jobs:
           path: ./dist
 
   deploy:
-    needs: [build-linux-glibc, build-linux-musl, build-macos, build-windows]
+    needs:
+      - build-linux-glibc-x86-64
+      - build-linux-musl-x86-64
+      - build-linux-glibc-aarch64
+      - build-linux-musl-aarch64
+      - build-macos
+      - build-windows
     environment:
       name: pypi
       url: https://pypi.org/project/stream-inflate/


### PR DESCRIPTION
In 549d017b51bdc79bdba8e2cbd448bdb300dabe24 when I changed the job names I forgot to update the dependencies of the upstream job to match them. And I forgot to update the dependencies with the new tasks as well.