### PR TITLE
feat: drop support for Python 3.6 (and increase minimim Python 3.7 version)

### DIFF
--- a/.github/workflows/deploy-package-to-pypi.yml
+++ b/.github/workflows/deploy-package-to-pypi.yml
@@ -42,7 +42,6 @@ jobs:
           - "musllinux_1_1_aarch64"
           - "musllinux_1_2_armv7l"
         folder:
-          - "cp36-cp36m"
           - "cp37-cp37m"
           - "cp38-cp38"
           - "cp39-cp39"
@@ -88,8 +87,7 @@ jobs:
           - "macos-13"
           - "macos-14"  # ARM
         python-version:
-          - "3.6.7"
-          - "3.7.1"
+          - "3.7.7"
           - "3.8.10"
           - "3.9.13"
           - "3.10.11"
@@ -97,9 +95,7 @@ jobs:
           - "3.12.6"
           - "3.13.0"
         exclude:
-          - python-version: "3.6.7"
-            os: "macos-14"
-          - python-version: "3.7.1"
+          - python-version: "3.7.7"
             os: "macos-14"
     runs-on: '${{ matrix.os }}'
 
@@ -131,8 +127,7 @@ jobs:
         os:
           - "windows-2019"
         python-version:
-          - "3.6.7"
-          - "3.7.1"
+          - "3.7.7"
           - "3.8.0"
           - "3.9.0"
           - "3.10.0"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,30 +12,32 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: "3.6.7"
-            os: "ubuntu-20.04"
-          - python-version: "3.7.1"
-            os: "ubuntu-20.04"
-          - python-version: "3.8.0"
-            os: "ubuntu-20.04"
+          - python-version: "3.7.7"
+            os: "ubuntu-24.04"
+          - python-version: "3.8.2"
+            os: "ubuntu-24.04"
           - python-version: "3.9.0"
-            os: "ubuntu-20.04"
+            os: "ubuntu-24.04"
           - python-version: "3.10.0"
-            os: "ubuntu-20.04"
-          - python-version: "3.11.0"
-            os: "ubuntu-20.04"
+            os: "ubuntu-24.04"
+          - python-version: "3.11.1"
+            os: "ubuntu-24.04"
           - python-version: "3.12.0"
-            os: "ubuntu-20.04"
+            os: "ubuntu-24.04"
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v3"
-      - uses: "actions/setup-python@v4"
+      - name: Install uv and set the python version
+        uses: astral-sh/setup-uv@v6
         with:
-          python-version: '${{ matrix.python-version }}'
+          # Pin to be able to install older Python
+          version: "0.6.17"
+          python-version: ${{ matrix.python-version }}
+          activate-environment: true
       - name: "Install python dependencies"
         run: |
-          STREAM_INFLATE_CODE_COVERAGE=1 pip install '.[dev]'
+          STREAM_INFLATE_CODE_COVERAGE=1 uv pip install '.[dev]'
           STREAM_INFLATE_CODE_COVERAGE=1 python setup.py build_ext --inplace
       - name: "Run tests"
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 ]
 description = "Uncompress DEFLATE streams in pure Python (albeit compiled with Cython)"
 readme = "README.md"
-requires-python = ">=3.6.7, !=3.7.0"
+requires-python = ">=3.7.7"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
This drops support for Python 3.6, and increases the minimum Python 3.7 version from 3.7.1 to 3.7.7, and moves to uv for installing Python on Linux

This is because GitHub's ubuntu runner + setup-python action no longer supports the older versions, and uv seems to support more older Python versions's that GitHub's setup-python action.