### PR TITLE
ci: avoid building wheels for what is now not supported Python

### DIFF
--- a/.github/workflows/build-source-package-and-wheels.yml
+++ b/.github/workflows/build-source-package-and-wheels.yml
@@ -45,7 +45,6 @@ jobs:
           - "musllinux_1_1_aarch64"
           - "musllinux_1_2_armv7l"
         folder:
-          - "cp36-cp36m"
           - "cp37-cp37m"
           - "cp38-cp38"
           - "cp39-cp39"
@@ -91,8 +90,7 @@ jobs:
           - "macos-13"
           - "macos-14"  # ARM
         python-version:
-          - "3.6.7"
-          - "3.7.1"
+          - "3.7.7"
           - "3.8.10"
           - "3.9.13"
           - "3.10.11"
@@ -161,8 +159,7 @@ jobs:
         os:
           - "windows-2019"
         python-version:
-          - "3.6.7"
-          - "3.7.1"
+          - "3.7.7"
           - "3.8.0"
           - "3.9.0"
           - "3.10.0"


### PR DESCRIPTION
Recently dropped support for Python 3.6, so similarly not building wheels files for these versions (and just for completeness, building 3.7 on exactly the minimum supported version, Python 3.7.7)