### PR TITLE
ci: fix skipping of building arm macOS wheel on Python 3.7

### DIFF
--- a/.github/workflows/build-source-package-and-wheels.yml
+++ b/.github/workflows/build-source-package-and-wheels.yml
@@ -100,7 +100,7 @@ jobs:
         exclude:
           - python-version: "3.6.7"
             os: "macos-14"
-          - python-version: "3.7.1"
+          - python-version: "3.7.7"
             os: "macos-14"
     runs-on: '${{ matrix.os }}'
 


### PR DESCRIPTION
Recently changed what version of Python was used to build Python 3.7 wheels. However, missed that there was a skip of a version since arm Python on macOS isn't always available.