### PR TITLE
ci: overwrite files in publish without prompt

### DIFF
--- a/.github/workflows/deploy-package-to-pypi.yml
+++ b/.github/workflows/deploy-package-to-pypi.yml
@@ -32,7 +32,7 @@ jobs:
       # to the top level for upload
       - name: Move packages to top level
         run: |
-          find ./dist -mindepth 2 -type f -exec mv -t ./dist -i '{}' +
+          find ./dist -mindepth 2 -type f -exec mv -f -t ./dist '{}' +
           rm -R -- ./dist/*/
 
       - name: Publish package distributions to PyPI


### PR DESCRIPTION
Gathering wheel files in the publish was failing, because it was prompting for comfirmation before overriding.