### PR TITLE
build: Python 3.13 & 3.14 wheels

### DIFF
--- a/.github/workflows/build-source-package-and-wheels.yml
+++ b/.github/workflows/build-source-package-and-wheels.yml
@@ -41,8 +41,10 @@ jobs:
         image:
           - "manylinux2014_x86_64"
           - "musllinux_1_1_x86_64"
+          - "musllinux_1_2_x86_64"
           - "manylinux2014_aarch64"
           - "musllinux_1_1_aarch64"
+          - "musllinux_1_2_aarch64"
           - "musllinux_1_2_armv7l"
         folder:
           - "cp37-cp37m"
@@ -52,6 +54,19 @@ jobs:
           - "cp311-cp311"
           - "cp312-cp312"
           - "cp313-cp313"
+          - "cp314-cp314"
+        exclude:
+          - image: "musllinux_1_1_x86_64"
+            folder: "cp314-cp314"
+          - image: "musllinux_1_1_aarch64"
+            folder: "cp314-cp314"
+
+    env:
+      # From https://github.com/uktrade/stream-unzip/blob/main/.github/workflows/build-source-package-and-wheels.yml
+      # 2024.10.26-1 supports 3.7 to 3.13 for musl 1.1 and is the last musl 1.1 version
+      # 2025.05.03-1 supports 3.7 to 3.13 for musl 1.2 and manylinux
+      # 2026.03.01-1 is the latest version at the time of writing
+      TAG: ${{ case(startsWith(matrix.image, 'musllinux_1_1_'), '2024.10.26-1', matrix.folder == 'cp314-cp314', '2026.03.01-1', '2025.05.03-1') }}
 
     steps:
       - uses: actions/checkout@v4
@@ -68,7 +83,7 @@ jobs:
 
       - name: Build packages
         run: >-
-          docker run --rm -v ${{ github.workspace }}:/app quay.io/pypa/${{ matrix.image }} bash -c '
+          docker run --rm -v ${{ github.workspace }}:/app quay.io/pypa/${{ matrix.image }}:$TAG bash -c '
             cd /app &&
             /opt/python/${{ matrix.folder }}/bin/python -m build --wheel
             auditwheel repair $(ls dist/*.whl) &&
@@ -86,7 +101,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - "macos-13"
           - "macos-14"  # ARM
           - "macos-15"  # ARM
         python-version:
@@ -97,6 +111,7 @@ jobs:
           - "3.11.9"
           - "3.12.6"
           - "3.13.0"
+          - "3.14.0"
         exclude:
           - python-version: "3.6.7"
             os: "macos-14"
@@ -159,7 +174,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - "windows-2019"
+          - "windows-2022"
         python-version:
           - "3.7.7"
           - "3.8.0"
@@ -168,6 +183,7 @@ jobs:
           - "3.11.0"
           - "3.12.0"
           - "3.13.0"
+          - "3.14.0"
     runs-on: '${{ matrix.os }}'
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,10 @@ jobs:
             os: "ubuntu-24.04"
           - python-version: "3.12.0"
             os: "ubuntu-24.04"
+          - python-version: "3.13.0"
+            os: "ubuntu-24.04"
+          - python-version: "3.14.0"
+            os: "ubuntu-24.04"
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout"
@@ -37,13 +41,14 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           # Pin to be able to install older Python
-          version: "0.6.17"
+          version: ${{ matrix.python-version == '3.7.7' && '0.6.17' || '0.10.6' }}
           python-version: ${{ matrix.python-version }}
           activate-environment: true
       - name: "Install python dependencies"
+        # Suspect code coverage is contributing factor to cancellation in GitHub actions, but seems fine on Python 3.14
         run: |
-          STREAM_INFLATE_CODE_COVERAGE=1 uv pip install '.[dev]'
-          STREAM_INFLATE_CODE_COVERAGE=1 python setup.py build_ext --inplace
+          CC=clang STREAM_INFLATE_CODE_COVERAGE=${{ matrix.python-version == '3.14.0' && '1' || '0' }} uv pip install '.[dev]'
+          CC=clang STREAM_INFLATE_CODE_COVERAGE=${{ matrix.python-version == '3.14.0' && '1' || '0' }}  python setup.py build_ext --inplace
       - name: "Run tests"
         run: |
           pytest --cov -v


### PR DESCRIPTION
Also
- Builds for musl 1.2 while at it
- Drops building on macOS 13 (since GitHub actions does not support it any longer)
- Moves from windows-2019 to windows-2022 (since GitHub actions no longer supports windows-2019)
- Adds in CC=clang in tests to avoid cc: error: unrecognized command-line option ‘-fdebug-default-version=4’